### PR TITLE
Errors when attempting to dequeue/dequeueEnd on an empty queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,21 @@
 
 qewe is a type-safe, zero-dependency max/min priority queue manager for JavaScript and TypeScript projects.
 
+```ts
+import { Qewe } from 'qewe';
+
+const queue = new Qewe();
+queue.enqueue('hello', 1);
+queue.enqueue('world', 2);
+
+console.log(queue.values); // [ 'world', 'hello' ]
+console.log(queue.size); // 2
+
+const value = queue.dequeue();
+console.log(value); // 'world'
+console.log(queue.size); // 1
+```
+
 ## Installation
 
 Add qewe to your project using your favorite package manager:
@@ -18,24 +33,7 @@ You can also import qewe with a script tag via [unpkg](https://unpkg.com):
 <script src="//unpkg.com/qewe" type="text/javascript"></script>
 ```
 
-## Basic Usage
-
-```ts
-import { Qewe } from 'qewe';
-
-const queue = new Qewe();
-queue.enqueue('hello', 1);
-queue.enqueue('world', 2);
-
-console.log(queue.values); // [ 'world', 'hello' ]
-console.log(queue.size); // 2
-
-const value = queue.pop();
-console.log(value); // 'world'
-console.log(queue.size); // 1
-```
-
-## API
+## Usage
 
 ### Types
 
@@ -74,14 +72,44 @@ const queue: new Qewe<{ x: number; y: number; mass: number }>({
 
   `isMinQueue` is `false` by default, resulting in a max-priority queue.
 
+### Queue Behavior
+
+Instances which have an empty queue will throw an error when `dequeue` or `dequeueEnd` are called. It is recommended that you expect this error and handle it accordingly:
+
+```ts
+const queue = new Qewe();
+
+try {
+  const value = queue.dequeue();
+} catch {
+  // queue is empty - do something else
+}
+```
+
+Alternatively, you can check if the queue is empty _before_ you attempt to dequeue:
+
+```ts
+const queue = new Qewe();
+
+if (queue.isEmpty) {
+  // queue is empty - do something else
+} else {
+  const value = queue.dequeue();
+}
+```
+
+The `peek` and `peekEnd` properties of an instance do _not_ throw an error when the queue is empty. Instead, they return `undefined`.
+
+## API
+
 ### Instance Properties
 
 ```ts
 // see the next entry in the queue without removing it
-Qewe.prototype.peek: T | null;
+Qewe.prototype.peek: T | undefined;
 
 // see the final entry in the queue without removing it
-Qewe.prototype.peekEnd: T | null;
+Qewe.prototype.peekEnd: T | undefined;
 
 // list all values in the queue
 Qewe.prototype.values: T[];
@@ -107,10 +135,10 @@ Qewe.prototype.enqueue(value: T, priority: number): QeweEntry<T>;
 Qewe.prototype.enqueue(value: T): QeweEntry<T>;
 
 // get the first entry in the queue and remove it from the queue
-Qewe.prototype.dequeue(): T | null;
+Qewe.prototype.dequeue(): T;
 
 // get the last entry in the queue and remove it from the queue
-Qewe.prototype.dequeueEnd(): T | null;
+Qewe.prototype.dequeueEnd(): T;
 
 // remove all entries from the queue and return them
 Qewe.prototype.clear(): QeweEntry<T>[];

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,13 +19,13 @@ class Qewe<T> {
   }
 
   /** see the next entry in the queue without removing it */
-  get peek(): T | null {
-    return this.queue[0]?.value ?? null;
+  get peek(): T | undefined {
+    return this.queue[0]?.value;
   }
 
   /** see the final entry in the queue without removing it */
-  get peekEnd(): T | null {
-    return this.queue[this.queue.length - 1]?.value ?? null;
+  get peekEnd(): T | undefined {
+    return this.queue[this.queue.length - 1]?.value;
   }
 
   /** list all values in the queue */
@@ -52,9 +52,9 @@ class Qewe<T> {
   enqueue(value: T): QeweEntry<T>;
   enqueue(value: T, priority: number): QeweEntry<T>;
   enqueue(value: T, priority?: number): QeweEntry<T> {
-    const entryPriority = priority ?? this.inferValuePriority?.(value) ?? null;
+    const entryPriority = priority ?? this.inferValuePriority?.(value);
 
-    if (entryPriority === null) {
+    if (entryPriority === undefined) {
       throw new Error(
         "No priority value, or function to infer an entry's priority value, was provided.",
       );
@@ -86,24 +86,24 @@ class Qewe<T> {
   }
 
   /** get the first entry in the queue and remove it from the queue */
-  dequeue(): T | null {
+  dequeue(): T {
     const entry = this.queue.shift();
 
     if (entry !== undefined) {
       return entry.value;
     } else {
-      return null;
+      throw new Error('Dequeue failed - the queue is empty.');
     }
   }
 
   /** get the last entry in the queue and remove it from the queue */
-  dequeueEnd(): T | null {
+  dequeueEnd(): T {
     const entry = this.queue.pop();
 
     if (entry !== undefined) {
       return entry.value;
     } else {
-      return null;
+      throw new Error('Dequeue failed - the queue is empty.');
     }
   }
 

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -35,14 +35,16 @@ describe('queue functionality', () => {
     expect(entries).toStrictEqual([{ priority: 1, value: 'a' }]);
   });
 
-  it('returns null if the queue is empty and a dequeue is attempted', () => {
-    const value = queue.dequeue();
-
-    expect(value).toBe(null);
+  it('throws an error if the queue is empty and a dequeue is attempted', () => {
+    expect(() => queue.dequeue()).toThrowError(
+      'Dequeue failed - the queue is empty.',
+    );
   });
 
   it('throws an error if no priority is provided', () => {
-    expect(() => queue.enqueue('d')).toThrowError();
+    expect(() => queue.enqueue('d')).toThrowError(
+      "No priority value, or function to infer an entry's priority value, was provided.",
+    );
   });
 });
 


### PR DESCRIPTION
This PR addresses #1.

`dequeue` and `dequeueEnd` now throw an error if they are called when the queue is empty:

```ts
dequeue(): T {
  const entry = this.queue.shift();

  if (entry !== undefined) {
    return entry.value;
  } else {
    throw new Error('Dequeue failed - the queue is empty.');
  }
}
```

The documentation in the README file has been updated to suggest users wrap their `dequeue`/`dequeueEnd` calls in a `try/catch` block. It also provides an alternative suggestion, noted in the original issue, where users can instead check for themselves if the queue is empty before attempting a `dequeue`.