### PR TITLE
QeweEntry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -123,7 +123,7 @@ class Qewe<T> {
     return new QeweEntry(value, entryPriority);
   }
 
-  /** add a new value to the queue. returns the new queue entry. */
+  /** add a new entry to the queue. returns the new queue entry. */
   enqueue(entry: QeweEntry<T>): QeweEntry<T>;
   enqueue(value: T): QeweEntry<T>;
   enqueue(value: T, priority: number): QeweEntry<T>;

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -1,187 +1,202 @@
-import { Qewe, QeweErrors } from '../src/index';
+import { Qewe, QeweEntry, QeweErrors } from '../src/index';
 
-describe('queue functionality', () => {
-  const queue = new Qewe<string>({ queueType: 'max', maximumQueueSize: 10 });
+describe('QeweEntry', () => {
+  it('should create an entry', () => {
+    const entry = new QeweEntry('test', 1);
 
-  describe('initialized queue', () => {
-    it('returns its configuration parameters', () => {
-      expect(queue.queueType).toBe('max');
-      expect(queue.maxSize).toBe(10);
-    });
-
-    it('should be empty', () => {
-      expect(queue.isEmpty).toBe(true);
-      expect(queue.peek).toBe(undefined);
-      expect(queue.peekEnd).toBe(undefined);
-    });
-  });
-
-  describe('enqueue', () => {
-    it('inserts a value', () => {
-      queue.enqueue('a', 1);
-
-      expect(queue.peek).toBe('a');
-    });
-
-    it('inserts a higher priority entry in the first position', () => {
-      queue.enqueue('b', 2);
-
-      expect(queue.peek).toBe('b');
-      expect(queue.peekEnd).toBe('a');
-    });
-  });
-
-  describe('queue state', () => {
-    it('has an iterator', () => {
-      const values = [...queue];
-
-      expect(values).toEqual(['b', 'a']);
-    });
-
-    it('can list its values', () => {
-      expect(queue.values).toStrictEqual(['b', 'a']);
-    });
-
-    it('can list its entries', () => {
-      expect(queue.entries).toStrictEqual([
-        { value: 'b', priority: 2 },
-        { value: 'a', priority: 1 },
-      ]);
-    });
-
-    it('can check for the existence of a value', () => {
-      expect(queue.contains('a')).toBe(true);
-      expect(queue.contains('b')).toBe(true);
-      expect(queue.contains('c')).toBe(false);
-    });
-  });
-
-  describe('dequeue/removal', () => {
-    it('can remove a given value', () => {
-      queue.enqueue('c', 3);
-      expect(queue.size).toBe(3);
-
-      const removed = queue.remove('c');
-      expect(removed).toStrictEqual({ value: 'c', priority: 3 });
-      expect(queue.size).toBe(2);
-    });
-
-    it('dequeues the next value', () => {
-      const dequeued = queue.dequeue();
-
-      expect(queue.size).toBe(1);
-      expect(queue.peek).toBe('a');
-      expect(dequeued).toBe('b');
-    });
-
-    it('dequeues the final value', () => {
-      queue.enqueue('d', 0);
-
-      const dequeued = queue.dequeueEnd();
-
-      expect(queue.size).toBe(1);
-      expect(queue.peek).toBe('a');
-      expect(dequeued).toBe('d');
-    });
-
-    it('removes and returns all entries when cleared', () => {
-      const entries = queue.clear();
-
-      expect(queue.isEmpty).toBe(true);
-      expect(entries).toStrictEqual([{ priority: 1, value: 'a' }]);
-    });
-  });
-
-  describe('errors', () => {
-    it('throws an error if a dequeue is attempted when there are no entries', () => {
-      expect(() => queue.dequeue()).toThrowError(QeweErrors.EmptyQueue);
-      expect(() => queue.dequeueEnd()).toThrowError(QeweErrors.EmptyQueue);
-    });
-
-    it('throws an error if no priority is provided', () => {
-      expect(() => queue.enqueue('d')).toThrowError(QeweErrors.NoPriorityValue);
-    });
-
-    it('throws an error if the value to be removed does not exist', () => {
-      expect(() => queue.remove('e')).toThrowError(QeweErrors.NotFound);
-    });
+    expect(entry).toBeInstanceOf(QeweEntry);
+    expect(entry.priority).toBe(1);
+    expect(entry.value).toBe('test');
   });
 });
 
-describe('queue configuration', () => {
-  describe('min queue', () => {
-    const queue = new Qewe<string>({ queueType: 'min' });
+describe('Qewe', () => {
+  describe('configuration', () => {
+    describe('min queue', () => {
+      const queue = new Qewe<string>({ queueType: 'min' });
 
-    it('adds values in reverse priority order', () => {
-      queue.enqueue('a', 1);
-      queue.enqueue('b', 2);
+      it('adds values in reverse priority order', () => {
+        queue.enqueue('a', 1);
+        queue.enqueue('b', 2);
 
-      expect(queue.size).toBe(2);
-      expect(queue.peek).toBe('a');
-      expect(queue.peekEnd).toBe('b');
-    });
-
-    it('removes values in reverse priority order', () => {
-      const popped = queue.dequeue();
-
-      expect(queue.size).toBe(1);
-      expect(queue.peek).toBe('b');
-      expect(popped).toBe('a');
-    });
-  });
-
-  describe('inferred priority', () => {
-    const queue = new Qewe<{ x: number; y: number; mass: number }>({
-      inferValuePriority: (value) => value.mass,
-    });
-
-    it('infers the priority of a value based on a provided function', () => {
-      queue.enqueue({ x: 1, y: 1, mass: 1 });
-      queue.enqueue({ x: 2, y: -3, mass: 4 });
-      queue.enqueue({ x: 3, y: 4, mass: 7 });
-      queue.enqueue({ x: -3, y: 9, mass: 0.5 });
-
-      expect(queue.size).toBe(4);
-      expect(queue.peek).toStrictEqual({ x: 3, y: 4, mass: 7 });
-      expect(queue.peekEnd).toStrictEqual({ x: -3, y: 9, mass: 0.5 });
-    });
-  });
-
-  describe('max queue size', () => {
-    const queue = new Qewe<string>({ maximumQueueSize: 3 });
-
-    it('prevents entries from being queued when the maximum size is reached', () => {
-      queue.enqueue('a', 3);
-      queue.enqueue('b', 1);
-      queue.enqueue('c', 2);
-
-      expect(() => queue.enqueue('d', 4)).toThrowError(
-        QeweErrors.MaxQueueSizeReached,
-      );
-    });
-  });
-
-  describe('initialize with entries', () => {
-    it('initializes with stated priority', () => {
-      const queue = new Qewe<{ x: number; y: number }>({
-        initialValues: [
-          { value: { x: 1, y: 1 }, priority: 1 },
-          { value: { x: 1, y: 1 }, priority: 3 },
-        ],
+        expect(queue.size).toBe(2);
+        expect(queue.peek).toBe('a');
+        expect(queue.peekEnd).toBe('b');
       });
 
-      expect(queue.size).toBe(2);
-      expect(queue.peek).toStrictEqual({ x: 1, y: 1 });
+      it('removes values in reverse priority order', () => {
+        const popped = queue.dequeue();
+
+        expect(queue.size).toBe(1);
+        expect(queue.peek).toBe('b');
+        expect(popped).toBe('a');
+      });
     });
 
-    it('initializes with inferred priority', () => {
-      const queue = new Qewe<string>({
-        inferValuePriority: (value) => value.length,
-        initialValues: ['hello', 'world', 'initializing', 'test'],
+    describe('inferred priority', () => {
+      const queue = new Qewe<{ x: number; y: number; mass: number }>({
+        inferValuePriority: (value) => value.mass,
       });
 
-      expect(queue.size).toBe(4);
-      expect(queue.peek).toBe('initializing');
+      it('infers the priority of a value based on a provided function', () => {
+        queue.enqueue({ x: 1, y: 1, mass: 1 });
+        queue.enqueue({ x: 2, y: -3, mass: 4 });
+        queue.enqueue({ x: 3, y: 4, mass: 7 });
+        queue.enqueue({ x: -3, y: 9, mass: 0.5 });
+
+        expect(queue.size).toBe(4);
+        expect(queue.peek).toEqual({ x: 3, y: 4, mass: 7 });
+        expect(queue.peekEnd).toEqual({ x: -3, y: 9, mass: 0.5 });
+      });
+    });
+
+    describe('max queue size', () => {
+      const queue = new Qewe<string>({ maximumQueueSize: 3 });
+
+      it('prevents entries from being queued when the maximum size is reached', () => {
+        queue.enqueue('a', 3);
+        queue.enqueue('b', 1);
+        queue.enqueue('c', 2);
+
+        expect(() => queue.enqueue('d', 4)).toThrowError(
+          QeweErrors.MaxQueueSizeReached,
+        );
+      });
+    });
+
+    describe('initialize with entries', () => {
+      it('initializes with stated priority', () => {
+        const queue = new Qewe<{ x: number; y: number }>({
+          initialEntries: [
+            new QeweEntry({ x: 1, y: 1 }, 1),
+            new QeweEntry({ x: 1, y: 1 }, 3),
+          ],
+        });
+
+        expect(queue.size).toBe(2);
+        expect(queue.peek).toEqual({ x: 1, y: 1 });
+      });
+
+      it('initializes with inferred priority', () => {
+        const queue = new Qewe<string>({
+          inferValuePriority: (value) => value.length,
+          initialValues: ['hello', 'world', 'initializing', 'test'],
+        });
+
+        expect(queue.size).toBe(4);
+        expect(queue.peek).toBe('initializing');
+      });
+    });
+  });
+
+  describe('queue functionality', () => {
+    const queue = new Qewe<string>({ queueType: 'max', maximumQueueSize: 10 });
+
+    describe('initialized queue', () => {
+      it('returns its configuration parameters', () => {
+        expect(queue.queueType).toBe('max');
+        expect(queue.maxSize).toBe(10);
+      });
+
+      it('should be empty', () => {
+        expect(queue.isEmpty).toBe(true);
+        expect(queue.peek).toBe(undefined);
+        expect(queue.peekEnd).toBe(undefined);
+      });
+    });
+
+    describe('enqueue', () => {
+      it('inserts a value', () => {
+        queue.enqueue(new QeweEntry('a', 1));
+
+        expect(queue.peek).toBe('a');
+        expect(queue.entries[0]).toBeInstanceOf(QeweEntry);
+      });
+
+      it('inserts a higher priority entry in the first position', () => {
+        queue.enqueue('b', 2);
+
+        expect(queue.peek).toBe('b');
+        expect(queue.peekEnd).toBe('a');
+      });
+    });
+
+    describe('queue state', () => {
+      it('has an iterator', () => {
+        const values = [...queue];
+
+        expect(values).toEqual(['b', 'a']);
+      });
+
+      it('can list its values', () => {
+        expect(queue.values).toEqual(['b', 'a']);
+      });
+
+      it('can list its entries', () => {
+        expect(queue.entries).toEqual([
+          { value: 'b', priority: 2 },
+          { value: 'a', priority: 1 },
+        ]);
+      });
+
+      it('can check for the existence of a value', () => {
+        expect(queue.contains('a')).toBe(true);
+        expect(queue.contains('b')).toBe(true);
+        expect(queue.contains('c')).toBe(false);
+      });
+    });
+
+    describe('dequeue/removal', () => {
+      it('can remove a given value', () => {
+        queue.enqueue('c', 3);
+        expect(queue.size).toBe(3);
+
+        const removed = queue.remove('c');
+        expect(removed).toEqual({ value: 'c', priority: 3 });
+        expect(queue.size).toBe(2);
+      });
+
+      it('dequeues the next value', () => {
+        const dequeued = queue.dequeue();
+
+        expect(queue.size).toBe(1);
+        expect(queue.peek).toBe('a');
+        expect(dequeued).toBe('b');
+      });
+
+      it('dequeues the final value', () => {
+        queue.enqueue('d', 0);
+
+        const dequeued = queue.dequeueEnd();
+
+        expect(queue.size).toBe(1);
+        expect(queue.peek).toBe('a');
+        expect(dequeued).toBe('d');
+      });
+
+      it('removes and returns all entries when cleared', () => {
+        const entries = queue.clear();
+
+        expect(queue.isEmpty).toBe(true);
+        expect(entries).toEqual([{ priority: 1, value: 'a' }]);
+      });
+    });
+
+    describe('errors', () => {
+      it('throws an error if a dequeue is attempted when there are no entries', () => {
+        expect(() => queue.dequeue()).toThrowError(QeweErrors.EmptyQueue);
+        expect(() => queue.dequeueEnd()).toThrowError(QeweErrors.EmptyQueue);
+      });
+
+      it('throws an error if no priority is provided', () => {
+        expect(() => queue.enqueue('d')).toThrowError(
+          QeweErrors.NoPriorityValue,
+        );
+      });
+
+      it('throws an error if the value to be removed does not exist', () => {
+        expect(() => queue.remove('e')).toThrowError(QeweErrors.NotFound);
+      });
     });
   });
 });


### PR DESCRIPTION
This PR, and subsequently release, adds a new `QeweEntry` class which is used by a `Qewe` instance to store values and their priorities.

`QeweEntry` instances can be created outside of a `Qewe` instance - either using the `new QeweEntry` constructor or the `.createEntry` method on a `Qewe` instance. They can then be inserted programatically.

```ts
const queue = new Qewe<string>();

const entry = new QeweEntry('hello', 1);
queue.enqueue(entry);

const anotherEntry = queue.createEntry('world', 2);
queue.enqueue(anotherEntry);
```

`.enqueue` still allows the `(value: T, priority?: number)` syntax:

```ts
const queue = new Qewe<string>();
queue.enqueue('hello', 1);
queue.enqueue('world', 2);

const inferrerdQueue = new Qewe<string>({ inferValuePriority: (value) => value.length });
inferredQueue.enqueue('hello');
inferredQueue.enqueue('world');
```

This is, however, a breaking change. The `initialValues` constructor option now **only** allows raw values and requires  the `inferValuePriority` to be set.

A new constructor option, `initialEntries`, has been added, which takes an array of `QeweEntry` instances.

```ts
// old behavior, no longer works
const queue = new Qewe({
  initialValues: [
    { value: 'hello', priority: 1 },
    { value: 'world', priority: 2 }
  ]
});

// new behavior
const firstEntry = new QeweEntry('hello', 1);
const secondEntry = new QeweEntry('world', 2);
const queue = new Qewe({ initialEntries: [firstEntry, secondEntry] });

// also works 
const queue = new Qewe({
  inferValuePriority: (value) => value.length,
  initialValues: ['hello', 'world']
});
```