### PR TITLE
Reactive Entries

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ enum QeweErrors {
 
 class QeweEntry<T> {
   readonly value: T;
-  readonly priority: number;
+  public priority: number;
 
   constructor(value: T, priority: number) {
     this.value = value;
@@ -68,6 +68,20 @@ class Qewe<T> {
         this.enqueue(initialValue);
       }
     }
+  }
+
+  protected _createReactivePriorityEntry(entry: QeweEntry<T>): QeweEntry<T> {
+    const proxy = new Proxy(entry, {
+      set: (obj, prop, value, receiver) => {
+        const result = Reflect.set(obj, prop, value, receiver);
+
+        if (prop === 'priority') this.sort();
+
+        return result;
+      },
+    });
+
+    return proxy;
   }
 
   /** get the amount of entries of the queue. */
@@ -145,6 +159,8 @@ class Qewe<T> {
     } else {
       newEntry = this.createEntry(value, priority);
     }
+
+    newEntry = this._createReactivePriorityEntry(newEntry);
 
     const priorityIndex = this.queue.findIndex((entry) => {
       // if this is a min queue we want to find the first entry in the queue

--- a/src/index.ts
+++ b/src/index.ts
@@ -196,6 +196,13 @@ class Qewe<T> {
     return this.queue.splice(index, 1)[0];
   }
 
+  /** sorts the queue by comparing each entry's priority */
+  sort(): QeweEntry<T>[] {
+    return this.queue.sort(
+      (a, b) => (a.priority - b.priority) * (this.queueType === 'max' ? -1 : 1),
+    );
+  }
+
   /** returns a generator that yields the queue's values */
   *values(): Generator<T> {
     const queueValues: T[] = this.queue.map((entry) => entry.value);

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,18 +70,22 @@ class Qewe<T> {
     }
   }
 
-  protected _createReactivePriorityEntry(entry: QeweEntry<T>): QeweEntry<T> {
-    const proxy = new Proxy(entry, {
+  protected _createQeweEntryProxy(entry: QeweEntry<T>): QeweEntry<T> {
+    const entryProxy = new Proxy(entry, {
       set: (obj, prop, value, receiver) => {
-        const result = Reflect.set(obj, prop, value, receiver);
+        if (prop === 'priority') {
+          const result = Reflect.set(obj, prop, value, receiver);
 
-        if (prop === 'priority') this.sort();
+          this.sort();
 
-        return result;
+          return result;
+        } else {
+          return false;
+        }
       },
     });
 
-    return proxy;
+    return entryProxy;
   }
 
   /** get the amount of entries of the queue. */
@@ -160,7 +164,7 @@ class Qewe<T> {
       newEntry = this.createEntry(value, priority);
     }
 
-    newEntry = this._createReactivePriorityEntry(newEntry);
+    newEntry = this._createQeweEntryProxy(newEntry);
 
     const priorityIndex = this.queue.findIndex((entry) => {
       // if this is a min queue we want to find the first entry in the queue


### PR DESCRIPTION
## Current Implementation

```ts
const queue = new Qewe();

const a = queue.enqueue('hello', 1);
const b = queue.enqueue('world', 2);

console.log(...queue); // [ 'world', 'hello' ]

a.priority = 3;

console.log(...queue); // [ 'hello', 'world' ]
```

This is achieved by wrapping the `QeweEntry` created in `.enqueue` in a Proxy that runs a `sort` method on the queue when the entry's `priority` value is changed.

## Problems

There is an inconsistency with the current implementation's behaviour if you pass a `QeweEntry` directly into `enqueue`:

```ts
const queue = new Qewe();

const a = new QeweEntry('hello', 1);
const b = new QeweEntry('world', 2);
queue.enqueue(a);
queue.enqueue(b);

console.log(...queue); // [ 'world', 'hello' ]

a.priority = 3;

console.log(...queue); // [ 'world', 'hello' ]
```

Because the original `QeweEntry` instance is being edited, and not the Proxied instance that `enqueue` creates, the `Qewe` instance is not aware of any priority changes and so does not react to the change.